### PR TITLE
Extending the test-cases with a "red"-test

### DIFF
--- a/MultiProcessCommunication/MultiProcessCommunication.csproj
+++ b/MultiProcessCommunication/MultiProcessCommunication.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MultiProcessCommunication</RootNamespace>
     <AssemblyName>MultiProcessCommunication</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/MultiProcessWorker.Test/MultiProcessWorker.Test.csproj
+++ b/MultiProcessWorker.Test/MultiProcessWorker.Test.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MultiProcessWorker.Test</RootNamespace>
     <AssemblyName>MultiProcessWorker.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/MultiProcessWorker.Test/ProcessWorkerTest.cs
+++ b/MultiProcessWorker.Test/ProcessWorkerTest.cs
@@ -13,6 +13,24 @@ namespace MultiProcessWorker.Test
         #region Tests
 
         [Test]
+        public void ProcessWorkerThrowingExceptionInVoidMethod()
+        {
+            Assert.Throws<ProcessWorkerRemoteException>(() =>
+            {
+                ProcessWorker.RunAndWait(VoidMethodWhichThrows);
+            });
+        }
+
+        [Test]
+        public void ProcessWorkerThrowingExceptionInIntMethod()
+        {
+            Assert.Throws<ProcessWorkerRemoteException>(() =>
+            {
+                ProcessWorker.RunAndWait(IntMethodWhichThrows);
+            });
+        }
+
+        [Test]
         public void ProcessWorkerOkTest()
         {
             var data = ProcessWorker.RunAndWait(RemoteExecute);
@@ -111,6 +129,17 @@ namespace MultiProcessWorker.Test
         #endregion Tests
 
         #region Test Methods
+
+        public static int IntMethodWhichThrows()
+        {
+            throw new Exception("THIS_EXCEPTION_FROM_INT_METHOD_SHOULD_BE_FORWARDED");
+            return 0;
+        }
+
+        public static void VoidMethodWhichThrows()
+        {
+            throw new Exception("THIS_EXCEPTION_FROM_VOID_METHOD_SHOULD_BE_FORWARDED");
+        }
 
         public string RemoteFailExecute()
         {

--- a/MultiProcessWorker/MultiProcessWorker.csproj
+++ b/MultiProcessWorker/MultiProcessWorker.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MultiProcessWorker</RootNamespace>
     <AssemblyName>MultiProcessWorker</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
The repository was extended with by two NUnit-Tests (plus a kind of 'upgrade' of the .net-framework-version; but this was rather 'accidentially', because of a non-opening project).

One test ("green") shows the "expected" behaviour (at least from the point-of-view of a non-author).
The other test ("red") was intended with a similiar behaviour, but this test failed.

I am going to investigate the behaviour of the "red"-test:
Either I can conclude that i used this repository in a wrong way or I can (hopefully) provide
another PR with a fix.

