### PR TITLE
Kind of "quick fix" which results in 100% "green" tests

### DIFF
--- a/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerClientBase.cs
+++ b/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerClientBase.cs
@@ -212,7 +212,22 @@ namespace MultiProcessWorker.Private.MultiProcessWorkerLogic
         {
             IsDisposedCheck();
 
-            return m_WorkCommandResults.ContainsKey(guid);
+            var isKeyContained = m_WorkCommandResults.ContainsKey(guid);
+            if (isKeyContained)
+            {
+                var result = m_WorkCommandResults[guid];
+                var exception = result.Exception;
+                if (exception != null)
+                {
+                    var innerException = exception.InnerException;
+                    if (innerException != null)
+                    {
+                        throw new ProcessWorkerRemoteException(exception);
+                    }
+                }
+            }
+
+            return isKeyContained;
         }
 
         /// <summary>


### PR DESCRIPTION
This "changeset" contains a kind of quickfix: iff the result (of a parallel process)
is ready than check whether an exception is contained in it,
throw this exception as the result does not matter as the 'control-flow' of the parallel process
was aborted anyway.

This "changeset" makes the previously commited "red" test-case "green":
so it is now possible to expect Exceptions (e.g. from Assertions-calls) in RunAndWait-calls of
methods with a void-return type.
