### PR TITLE
the Dispose-method of the hosted-object (cf. RemoteClass.Dispose in the tests) is never called

### DIFF
--- a/MultiProcessWorker.Test/ProcessWorkerHostedObjectTest.cs
+++ b/MultiProcessWorker.Test/ProcessWorkerHostedObjectTest.cs
@@ -34,6 +34,9 @@ namespace MultiProcessWorker.Test
 
         public void Dispose()
         {
+            // DEBUGGING
+            System.Diagnostics.Debugger.Launch();
+
             Console.WriteLine("Dispose");
         }
     }

--- a/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerClientBase.cs
+++ b/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerClientBase.cs
@@ -140,6 +140,7 @@ namespace MultiProcessWorker.Private.MultiProcessWorkerLogic
             m_ProcessEventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, processArguments.IpcProcessName);
 
             m_WorkerProcess = CreateProcess(processArguments.ToString());
+            m_WorkerProcess.EnableRaisingEvents = true;
             m_WorkerProcess.Exited += OnWorkerProcessExited;
             m_WorkerProcess.Disposed += OnWorkerProcessDisposed;
             m_WorkerProcess.Start();
@@ -444,6 +445,9 @@ namespace MultiProcessWorker.Private.MultiProcessWorkerLogic
         /// <param name="e"></param>
         private void OnWorkerProcessExited(object sender, EventArgs e)
         {
+            // DEBUGGING
+            System.Diagnostics.Debugger.Launch();
+
             HandleProcessExit(sender);
         }
 

--- a/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerRunner.cs
+++ b/MultiProcessWorker/Private/MultiProcessWorkerLogic/MultiProcessWorkerRunner.cs
@@ -103,6 +103,9 @@ namespace MultiProcessWorker.Private.MultiProcessWorkerLogic
 
             if (m_HostedObject != null)
             {
+                // DEBUGGING
+                System.Diagnostics.Debugger.Launch();
+
                 (m_HostedObject as IDisposable)?.Dispose();
                 m_HostedObject = null;
             }


### PR DESCRIPTION
i figured out that the Dispose of the HostedObject should be called in
when
if (m_HostedObject != null)
(in the MultiProcessWorkerRunner).

But this code block is never called, because of the Dispose-method of the runner is never called.

I can only guess: the m_ParentProcess does not exit but the MultiProcessWorkerClientBase,m_WorkerProcess (aka the client-process?) does exit, but
this information is never "tranmitted" because no-one registered to the event "RemoteProcessExit" before.

Im sorry, i don't get it: is it perhaps necessary that the Runner registers this event form the ClientBase and than it will call the HostedObject.Dispose() method?

Any help is very appreciated.
Many thanks in advance.